### PR TITLE
Update parse_data test for parquet validation

### DIFF
--- a/tests/test_parse_data.py
+++ b/tests/test_parse_data.py
@@ -15,15 +15,27 @@ import pandas as pd
 
 
 def parse_data():
+    """Load CSV test data, save and reload as Parquet."""
+    csv_path = TESTS_DIR / "data" / "testdata.csv"
+    parquet_path = OUTPUT_DIR / "testdata.parquet"
+
     # Load the CSV file into a DataFrame
-    testdata = pd.read_csv(TESTS_DIR / "data" / "testdata.csv", engine="pyarrow")
+    testdata = pd.read_csv(csv_path, engine="pyarrow")
 
     # Store testdata as Parquet file
-    testdata.to_parquet(OUTPUT_DIR / "testdata.parquet", engine="pyarrow")
+    testdata.to_parquet(parquet_path, engine="pyarrow")
 
-    # Drop current testdata and reload from Parquet, dtype_backend = 'pyarrow' can be used instead of Numpy
-    testdata = pd.read_parquet(OUTPUT_DIR / "testdata.parquet", engine="pyarrow")
+    # Reload from Parquet and return
+    return pd.read_parquet(parquet_path, engine="pyarrow")
 
 
 def test_parse_data():
-    assert parse_data() is None
+    df_parquet = parse_data()
+
+    # Parquet file should exist
+    parquet_path = OUTPUT_DIR / "testdata.parquet"
+    assert parquet_path.is_file()
+
+    # Data loaded from Parquet should match the original CSV
+    df_csv = pd.read_csv(TESTS_DIR / "data" / "testdata.csv", engine="pyarrow")
+    pd.testing.assert_frame_equal(df_parquet, df_csv)


### PR DESCRIPTION
## Summary
- update `parse_data` helper to return the DataFrame reloaded from Parquet
- enhance `test_parse_data` to assert that the Parquet file exists and matches CSV content

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_686f93942b048323bc7e46680291c9d4